### PR TITLE
Fix typo in sentence about origin of data

### DIFF
--- a/src/SvarnyJunak.CeskeObce.Web/Views/Home/About.cshtml
+++ b/src/SvarnyJunak.CeskeObce.Web/Views/Home/About.cshtml
@@ -4,7 +4,7 @@
 
 <main>
     <h2>Zdroj dat</h2>
-    <p>Všechna data o&nbsp;počtech obyvatel pochází ze&nbsp;stránek Českého statistickéh úřadu. Data v&nbsp;podobě si můžete stáhnout na stránce <a href="https://www.czso.cz/csu/czso/pocet-obyvatel-v-obcich">https://www.czso.cz/csu/czso/pocet-obyvatel-v-obcich</a>. Data jsou aktualizována každý rok ke&nbsp;konci dubna.</p>
+    <p>Všechna data o&nbsp;počtech obyvatel pochází ze&nbsp;stránek Českého statistickéh úřadu. Data v&nbsp;původní podobě si můžete stáhnout na stránce <a href="https://www.czso.cz/csu/czso/pocet-obyvatel-v-obcich">https://www.czso.cz/csu/czso/pocet-obyvatel-v-obcich</a>. Data jsou aktualizována každý rok ke&nbsp;konci dubna.</p>
     <br />
     <h2>Co dělat pokud je na&nbsp;stránce chyba?</h2>
     <p>


### PR DESCRIPTION
One word was probably accidentally removed in commit bc247efec1ab ("info page has max width"). This change puts it back.